### PR TITLE
SHA256 hash file (again) in order verify

### DIFF
--- a/verification.rb
+++ b/verification.rb
@@ -12,7 +12,7 @@ curve = OpenSSL::PKey::EC.new(group)
 curve.public_key = OpenSSL::PKey::EC::Point.new(group, claimed_public_key_bign)
 
 asn1 = File.binread("sig.asn1")
-claimed_signed_hash = File.binread(file_to_verify)
+claimed_signed_hash = OpenSSL::Digest::SHA256.digest(File.binread(file_to_verify))
 
 verifies = curve.dsa_verify_asn1(claimed_signed_hash, asn1)
 


### PR DESCRIPTION
In order to get the code to verify the hash, the file needs to be hashed _again_. The OpenSSL command line automatically does this, but using OpenSSL from Ruby you need to add this extra hash yourself.

I’m pretty sure this is related to BitCoin’s use of double SHA256, but I’m definitely not an expert here.
